### PR TITLE
Triggering resize on Editor.init

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -94,6 +94,7 @@
 		backgroundSprite.scale.y = 0.1 * this.canvas2d.height;
 
 		this.on("resize", this.onResize);
+		this.triggerResize();
 	}
 
 	p.onResize = function(w, h)


### PR DESCRIPTION
### FIXING
* Content bounds are 800 x 600 on initial load [[#12](https://github.com/pixijs/pixi-particles-editor/issues/12)]